### PR TITLE
Add sector category breakdown for internal vs external

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -35,3 +35,9 @@ class RegionResponse(BaseModel):
 
 class SectorResponse(BaseModel):
     sectores: list[str]
+
+
+class InternoExternoSectorSchema(BaseModel):
+    sector: Optional[str]
+    interno: float
+    externo: float


### PR DESCRIPTION
## Summary
- group internal vs external totals by sector category for a selected year
- expose `/api/interno_externo_sector/{year}` endpoint backed by Redis caching
- define schema for sector category breakdown

## Testing
- `python -m py_compile routers.py crud.py schemas.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb3ef9e9ec8330b1b102e15db28f91