### PR TITLE
Improve query performance with indexes and year filtering

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -1,15 +1,15 @@
 from sqlalchemy.orm import Session
-from sqlalchemy import func, cast, Integer, text
+from sqlalchemy import func, text
 from collections import defaultdict
 from models import DatosSadipem
 
 def get_datos(db: Session, region: str = None, sector: str = None):
-    year_col = cast(func.substr(DatosSadipem.fecha_contratacion, 1, 4), Integer)
+    year_col = func.substr(DatosSadipem.fecha_contratacion, 1, 4)
     query = db.query(DatosSadipem)
     # Filtro por año de fecha_contratacion entre 2018 y 2024
     query = query.filter(
-        year_col >= 2018,
-        year_col <= 2024
+        year_col >= "2018",
+        year_col <= "2024"
     )
     if region:
         query = query.filter(DatosSadipem.região == region)
@@ -48,12 +48,12 @@ def get_stats(db: Session):
     }
 
 def get_valores_por_ente(db: Session):
-    year_col = cast(func.substr(DatosSadipem.fecha_contratacion, 1, 4), Integer)
+    year_col = func.substr(DatosSadipem.fecha_contratacion, 1, 4)
     common_filters = [
         DatosSadipem.garantia_soberana == 'Si',
         DatosSadipem.tiempo_prestamo > 14,
-        year_col >= 2019,
-        year_col <= 2024,
+        year_col >= "2019",
+        year_col <= "2024",
     ]
 
     # Totales por ente
@@ -127,14 +127,15 @@ def get_valores_por_ente(db: Session):
 
 
 def get_interno_externo_por_sector(db: Session, year: int):
-    year_col = cast(func.substr(DatosSadipem.fecha_contratacion, 1, 4), Integer)
+    year_col = func.substr(DatosSadipem.fecha_contratacion, 1, 4)
+    str_year = str(year)
     resultados = (
         db.query(
             DatosSadipem.sector,
             DatosSadipem.tipo_deuda,
             func.sum(DatosSadipem.valor_usd).label('total_usd')
         )
-        .filter(year_col == year)
+        .filter(year_col == str_year)
         .group_by(DatosSadipem.sector, DatosSadipem.tipo_deuda)
         .all()
     )

--- a/database.py
+++ b/database.py
@@ -1,7 +1,30 @@
-from sqlalchemy import create_engine
+import logging
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker, declarative_base
 from config import SQLALCHEMY_DATABASE_URL
+
+logger = logging.getLogger(__name__)
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
+
+
+def _ensure_indexes() -> None:
+    """Create the indexes that keep the most common filters fast."""
+    index_statements = (
+        'CREATE INDEX IF NOT EXISTS idx_datos_sadipem_regiao ON datos_sadipem ("região")',
+        'CREATE INDEX IF NOT EXISTS idx_datos_sadipem_sector ON datos_sadipem (sector)',
+        'CREATE INDEX IF NOT EXISTS idx_datos_sadipem_tipo_deuda ON datos_sadipem (tipo_deuda)',
+        'CREATE INDEX IF NOT EXISTS idx_datos_sadipem_year ON datos_sadipem ((substr(fecha_contratacion, 1, 4)))',
+    )
+
+    try:
+        with engine.begin() as connection:
+            for statement in index_statements:
+                connection.execute(text(statement))
+    except Exception as exc:  # pragma: no cover - defensive: prevents startup failure
+        logger.warning("Could not ensure performance indexes exist: %s", exc)
+
+
+_ensure_indexes()


### PR DESCRIPTION
## Summary
- create database indexes for the columns used by the most common filters
- align year filtering with the indexed expression to avoid full table scans

## Testing
- not run (database-dependent changes)


------
https://chatgpt.com/codex/tasks/task_e_68f8f38447988330bd85d350660c9cac